### PR TITLE
Silence some clippy warnings

### DIFF
--- a/chacha20/src/backends/sse2.rs
+++ b/chacha20/src/backends/sse2.rs
@@ -54,7 +54,8 @@ impl<R: Unsigned> StreamBackend for Backend<R> {
             self.v[3] = _mm_add_epi32(self.v[3], _mm_set_epi32(0, 0, 0, 1));
 
             let block_ptr = block.as_mut_ptr() as *mut __m128i;
-            for i in 0..4 {
+            #[allow(clippy::needless_range_loop)]
+            for i in 0..4  {
                 _mm_storeu_si128(block_ptr.add(i), res[i]);
             }
         }

--- a/salsa20/src/backends/sse2.rs
+++ b/salsa20/src/backends/sse2.rs
@@ -58,6 +58,7 @@ impl<R: Unsigned> StreamBackend for Backend<R> {
             self.v[2] = _mm_add_epi64(self.v[2], _mm_set_epi64x(0, 1));
 
             let block_ptr = block.as_mut_ptr() as *mut __m128i;
+            #[allow(clippy::needless_range_loop)]
             for i in 0..4 {
                 _mm_storeu_si128(block_ptr.add(i), res[i]);
             }


### PR DESCRIPTION
clippy::needless_range_loop is causing  CI failure.
This change silences  warnings that appear on the CI machine.